### PR TITLE
avoid having 'sh -c "..."' as pid 1 (init) in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER eyeos
 ENV WHATAMI rabbit
 ENV DISCOVERY_HOSTS_FILE_PATH /etc/hosts
 ENV WorkDir /var/service
+WORKDIR ${WorkDir}
 ENV RABBITMQ_HOME /srv/rabbitmq_server-${RABBITMQ_VERSION}
 ENV RABBITMQ_CONFIG_FILE /etc/rabbitmq/rabbitmq
 ENV RABBITMQ_AUTH_PORT 7108
@@ -32,4 +33,4 @@ RUN rabbitmq-plugins enable rabbitmq_stomp --offline && \
 
 EXPOSE 5672 15671 15672 61613
 
-CMD ${WorkDir}/start.sh
+CMD ["./start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -6,4 +6,4 @@ sed -i 's/%RABBITMQ_AUTH_HOST%/'$RABBITMQ_AUTH_HOST'/g' ${RABBITMQ_CONFIG_FILE}.
 sed -i 's/%RABBITMQ_AUTH_PORT%/'$RABBITMQ_AUTH_PORT'/g' ${RABBITMQ_CONFIG_FILE}.config
 sed -i 's/<<"eyeos">>/<<"'$RABBITMQ_GUEST_PASSWD'">>/g' ${RABBITMQ_CONFIG_FILE}.config
 
-eyeos-run-server --serf rabbitmq-server
+exec eyeos-run-server --serf rabbitmq-server


### PR DESCRIPTION
Facts:
- Pid 1 is the one that receives SIGTERM when we run `docker stop`.
- Shell scripts swallow signals.
- If the `CMD` sentence in `Dockerfile` is not in the form of a JSON
  array, docker launches a shell to execute the `CMD`, using `sh -c
  "$CMD"`.

So, our pid 1 in the container was a `sh -c "..."` process, that did not
pass signals to `eyeos-run-server`, so `eyeos-run-server` never received
a `SIGTERM` when someone did `docker stop`, and docker ended up killing
our containers in a not-so-graceful way.

To avoid this, we need to specify the `CMD` in "execform" (see
https://docs.docker.com/engine/reference/builder/#cmd) so the pid 1
process in the container is our command instead of a wrapping `sh -c`.
In the CMD sentence, environment variables are not expanded, so we
cannot use `${InstallationDir}` or others there now (we could do that
before because the literal `${InstallationDir}` was passed to the shell,
and the shell was evaluating it, but now that no shell is present we
cannot use envars in the `CMD`. To avoid this we set a shell script as
our CMD, and in the script we `exec` the full command that we had on the
initial CMD. The `exec` part is very important, because this makes the
new process to replace the script process, so now eyeos-run-server is
the new pid 1 process, and it will receive all signals.

Unfortunately, rabbitmq takes a long time to finish once it receives
SIGTERM, but we will have to handle this increasing the timeout between
SIGTERM and SIGKILL in `docker stop`.
